### PR TITLE
Amazon EventBridge support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ An Ethereum event listener that bridges your smart contract events and backend m
 * HTTP Post
 * [RabbitMQ](https://www.rabbitmq.com/)
 * [Pulsar](https://pulsar.apache.org)
+* [Amazon EventBrige](https://aws.amazon.com/eventbridge/)
 
 
 For RabbitMQ, you can configure the following extra values
@@ -408,7 +409,7 @@ Example filtering by `FROM_ADDRES`, this will notify when a transactions fails w
 ## Broadcast Messages Format
 
 ###  Contract Events
-When a subscribed event is emitted, a JSON message is broadcast to the configured kafka topic or rabbit exchange (contract-events by default), with the following format:
+When a subscribed event is emitted, a JSON message is broadcast to the configured kafka topic or rabbit exchange (contract-events by default) or EventBridge Bus, with the following format:
 
 ```json
 {
@@ -435,7 +436,7 @@ When a subscribed event is emitted, a JSON message is broadcast to the configure
 ```
 
 ### Block Events
-When a new block is mined, a JSON message is broadcast to the configured kafka topic or rabbit exchange (block-events by default), with the following format:
+When a new block is mined, a JSON message is broadcast to the configured kafka topic or rabbit exchange (block-events by default) or EventBridge Bus, with the following format:
 
 ```json
  {
@@ -451,7 +452,7 @@ When a new block is mined, a JSON message is broadcast to the configured kafka t
 
 
 ### Transaction Events
-When a new transaction that matches a transaction monitor is mined, a JSON message is broadcast to the configured kafka topic or rabbit exchange (transaction-events by default), with the following format:
+When a new transaction that matches a transaction monitor is mined, a JSON message is broadcast to the configured kafka topic or rabbit exchange (transaction-events by default) or EventBridge Bus, with the following format:
 
 ```json
  {
@@ -503,7 +504,7 @@ Eventeum can either be configured by:
 | ETHEREUM_NUMBLOCKSTOREPLAY | 12 | Number of blocks to replay on node or service failure (ensures no blocks / events are missed on chain reorg) |
 | POLLING_INTERVAL | 10000 | The polling interval used by Web3j to get events from the blockchain. |
 | EVENTSTORE_TYPE | DB | The type of eventstore used in Eventeum. (See the Advanced section for more details) |
-| BROADCASTER_TYPE | KAFKA | The broadcast mechanism to use.  (KAFKA or HTTP or RABBIT) |
+| BROADCASTER_TYPE | KAFKA | The broadcast mechanism to use.  (KAFKA or HTTP or RABBIT or EVENT_BRIDGE) |
 | BROADCASTER_CACHE_EXPIRATIONMILLIS | 6000000 | The eventeum broadcaster has an internal cache of sent messages, which ensures that duplicate messages are not broadcast.  This is the time that a message should live within this cache. |
 | BROADCASTER_EVENT_CONFIRMATION_NUMBLOCKSTOWAIT | 12 | The number of blocks to wait (after the initial mined block) before broadcasting a CONFIRMED event |
 | BROADCASTER_EVENT_CONFIRMATION_NUMBLOCKSTOWAITFORMISSINGTX | 200 | After a fork, a transaction may disappear, and this is the number of blocks to wait on the new fork, before assuming that an event emitted during this transaction has been INVALIDATED |

--- a/config-examples/application-template-eventBridge.yml
+++ b/config-examples/application-template-eventBridge.yml
@@ -1,0 +1,13 @@
+ethereum:
+  nodes:
+    - name: default
+      url: ws://your-node-host
+      # username: my-username
+      # password: my-password
+
+broadcaster:
+  type: EVENT_BRIDGE
+
+eventBridge:
+  eventBusName: mainnet
+  source: eventeum

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -29,6 +29,7 @@
     <properties>
         <micrometer.version>1.1.0</micrometer.version>
         <java.version>1.8</java.version>
+        <aws.java.sdk.version>2.15.5</aws.java.sdk.version>
     </properties>
 
     <dependencies>
@@ -81,6 +82,11 @@
         	<groupId>org.apache.pulsar</groupId>
 			<artifactId>pulsar-client</artifactId>
 			<version>2.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>eventbridge</artifactId>
+            <version>${aws.java.sdk.version}</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/core/src/main/java/net/consensys/eventeum/chain/config/NodeBeanRegistrationStrategy.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/config/NodeBeanRegistrationStrategy.java
@@ -64,7 +64,7 @@ public class NodeBeanRegistrationStrategy {
             "%sNodeFailureListener";
 
     private static final String NODE_BLOCK_SUB_STRATEGY_BEAN_NAME =
-            "%sBlockSubscriptionStategy";
+            "%sBlockSubscriptionStrategy";
 
     private static final String WEB_SOCKET_CLIENT_BEAN_NAME = "%sWebSocketClient";
 

--- a/core/src/main/java/net/consensys/eventeum/config/BlockchainEventBroadcasterConfiguration.java
+++ b/core/src/main/java/net/consensys/eventeum/config/BlockchainEventBroadcasterConfiguration.java
@@ -17,6 +17,7 @@ package net.consensys.eventeum.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import net.consensys.eventeum.dto.event.filter.ContractEventFilter;
 import net.consensys.eventeum.dto.message.EventeumMessage;
+import net.consensys.eventeum.integration.EventBridgeSettings;
 import net.consensys.eventeum.integration.KafkaSettings;
 import net.consensys.eventeum.integration.PulsarSettings;
 import net.consensys.eventeum.integration.RabbitSettings;
@@ -97,6 +98,16 @@ public class BlockchainEventBroadcasterConfiguration {
     			new PulsarBlockChainEventBroadcaster(settings, mapper);
 
     	return onlyOnceWrap(broadcaster);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnProperty(name=BROADCASTER_PROPERTY, havingValue="EVENT_BRIDGE")
+    public BlockchainEventBroadcaster eventBridgeBlockChainEventBroadcaster(EventBridgeSettings settings) {
+        final BlockchainEventBroadcaster broadcaster =
+                new EventBridgeBlockChainEventBroadcaster(settings);
+
+        return onlyOnceWrap(broadcaster);
     }
 
 

--- a/core/src/main/java/net/consensys/eventeum/integration/EventBridgeSettings.java
+++ b/core/src/main/java/net/consensys/eventeum/integration/EventBridgeSettings.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.consensys.eventeum.integration;
+
+import lombok.Data;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * An encapsulation of EventBridge related properties.
+ *
+ * @author Danilo Tuler <danilo.tuler@cartesi.io>
+ */
+@Configuration
+@Data
+@ConditionalOnProperty(name="broadcaster.type", havingValue="EVENT_BRIDGE")
+public class EventBridgeSettings {
+
+    @Value("${eventBridge.eventBusName}")
+    private String eventBusName;
+
+    @Value("${eventBridge.source}")
+    private String source;
+
+}

--- a/core/src/main/java/net/consensys/eventeum/integration/broadcast/blockchain/EventBridgeBlockChainEventBroadcaster.java
+++ b/core/src/main/java/net/consensys/eventeum/integration/broadcast/blockchain/EventBridgeBlockChainEventBroadcaster.java
@@ -1,0 +1,71 @@
+package net.consensys.eventeum.integration.broadcast.blockchain;
+
+import net.consensys.eventeum.dto.block.BlockDetails;
+import net.consensys.eventeum.dto.event.ContractEventDetails;
+import net.consensys.eventeum.dto.message.BlockEvent;
+import net.consensys.eventeum.dto.message.ContractEvent;
+import net.consensys.eventeum.dto.message.EventeumMessage;
+import net.consensys.eventeum.dto.message.TransactionEvent;
+import net.consensys.eventeum.dto.transaction.TransactionDetails;
+import net.consensys.eventeum.integration.EventBridgeSettings;
+import net.consensys.eventeum.utils.JSON;
+import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsRequest;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
+
+import java.time.Instant;
+import java.util.Collections;
+
+public class EventBridgeBlockChainEventBroadcaster implements BlockchainEventBroadcaster {
+
+    private EventBridgeClient client;
+
+    private PutEventsRequestEntry.Builder entryBuilder;
+
+    public EventBridgeBlockChainEventBroadcaster(EventBridgeSettings settings) {
+        this.client = EventBridgeClient.builder().build();
+        this.entryBuilder = PutEventsRequestEntry.builder()
+                .eventBusName(settings.getEventBusName())
+                .source(settings.getSource());
+    }
+
+    @Override
+    public void broadcastNewBlock(BlockDetails block) {
+        final EventeumMessage<BlockDetails> message = new BlockEvent(block);
+        PutEventsRequestEntry entry = entryBuilder
+                .time(Instant.ofEpochSecond(block.getTimestamp().longValue()))
+                .detailType("BLOCK")
+                .detail(JSON.stringify(message))
+                .build();
+        send(entry);
+    }
+
+    @Override
+    public void broadcastContractEvent(ContractEventDetails eventDetails) {
+        final EventeumMessage<ContractEventDetails> message = new ContractEvent(eventDetails);
+        PutEventsRequestEntry entry = this.entryBuilder
+                .time(Instant.ofEpochSecond(eventDetails.getTimestamp().longValue()))
+                .resources(eventDetails.getAddress())
+                .detailType("CONTRACT_EVENT")
+                .detail(JSON.stringify(message))
+                .build();
+        send(entry);
+    }
+
+    @Override
+    public void broadcastTransaction(TransactionDetails transactionDetails) {
+        final EventeumMessage<TransactionDetails> message = new TransactionEvent(transactionDetails);
+        PutEventsRequestEntry entry = this.entryBuilder
+                .time(Instant.ofEpochSecond(transactionDetails.getTimestamp().longValue()))
+                .resources(transactionDetails.getContractAddress())
+                .detailType("TRANSACTION")
+                .detail(JSON.stringify(message))
+                .build();
+        send(entry);
+    }
+
+    protected void send(PutEventsRequestEntry entry) {
+        final PutEventsRequest request = PutEventsRequest.builder().entries(Collections.singletonList(entry)).build();
+        this.client.putEvents(request);
+    }
+}

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -96,3 +96,7 @@ kafka:
   security:
     protocol: ${KAFKA_SECURITY_PROTOCOL:PLAINTEXT}
   retries: ${KAFKA_RETRIES:10}
+
+eventBridge:
+  eventBusName: ${EVENT_BRIDGE_EVENT_BUS_NAME:eventeum}
+  source: ${EVENT_BRIDGE_SOURCE:eventeum}

--- a/server/docker-compose-eventbridge.yml
+++ b/server/docker-compose-eventbridge.yml
@@ -1,0 +1,29 @@
+version: '3'
+
+services:
+  eventeum:
+    image: eventeum/eventeum:latest
+    ports:
+    - "8060:8060"
+    depends_on:
+      - mongodb
+    environment:
+      SPRING_DATA_MONGODB_HOST: mongodb
+      ETHEREUM_NODE_URL: wss://ropsten.infura.io/ws
+      ETHEREUM_NODES_0_BLOCKSTRATEGY: PUBSUB
+      BROADCASTER_TYPE: EVENT_BRIDGE
+      EVENT_BRIDGE_EVENT_BUS_NAME: ropsten
+      AWS_REGION: us-east-1
+      AWS_ACCESS_KEY_ID: 
+      AWS_SECRET_ACCESS_KEY: 
+    networks:
+      - default
+
+  mongodb:
+    image: mongo:latest
+    ports:
+      - "27017:27017"
+    volumes:
+      - $HOME/mongodb/data/db:/data/db
+    networks:
+      - default

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -87,7 +87,9 @@ kafka:
     partitions: 1
     replicationSets: 1
 
-
+eventBridge:
+  eventBusName: ${EVENT_BRIDGE_EVENT_BUS_NAME:eventeum}
+  source: ${EVENT_BRIDGE_SOURCE:eventeum}
 
 
 management:


### PR DESCRIPTION
This PR adds a new broadcast type for [Amazon EventBridge](https://aws.amazon.com/eventbridge/)

This will allow the integration of eventeum to AWS cloud and serverless products like AWS Lambda.
