### PR TITLE
made ETHEREUM_NODE_ADD_TRANSCATION_REVERT_REASON flag work! :)

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ Eventeum can either be configured by:
 | ETHEREUM_NODE_URL | http://localhost:8545 | The default ethereum node url. |
 | ETHEREUM_NODE_BLOCKSTRATEGY | POLL | The strategy for obtaining block events for the ethereum node (POLL or PUBSUB).
 | ETHEREUM_NODE_HEALTHCHECK_POLLINTERVAL | 2000 | The interval time in ms, in which a request is made to the ethereum node, to ensure that the node is running and functional. |
-| ETHEREUM_NODE_ADD_TRANSACTION_REVERT_REASON | false | In case of a failing transaction it indicates if Eventeum should get the revert reason. Currently not working for Ganache and Parity.
+| ETHEREUM_NODES_0_ADD_TRANSACTION_REVERT_REASON | false | In case of a failing transaction it indicates if Eventeum should get the revert reason. Tested successfully for Ganache and Quorum only.
 | ETHEREUM_NUMBLOCKSTOREPLAY | 12 | Number of blocks to replay on node or service failure (ensures no blocks / events are missed on chain reorg) |
 | POLLING_INTERVAL | 10000 | The polling interval used by Web3j to get events from the blockchain. |
 | EVENTSTORE_TYPE | DB | The type of eventstore used in Eventeum. (See the Advanced section for more details) |

--- a/core/src/main/java/net/consensys/eventeum/chain/settings/NodeSettings.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/settings/NodeSettings.java
@@ -65,7 +65,7 @@ public class NodeSettings {
 
     private static final String BLOCK_STRATEGY_ATTRIBUTE = "blockStrategy";
 
-    private static final String TRANSACTION_REVERT_REASON_ATTRIBUTTE = "addTransactionRevertReason";
+    private static final String TRANSACTION_REVERT_REASON_ATTRIBUTTE = "add.transaction.revert.reason";
 
     private static final String MAX_IDLE_CONNECTIONS_ATTRIBUTTE = "maxIdleConnections";
 


### PR DESCRIPTION
I was not able to get the revert-reason for the failing transactions in Kafka events, when I looked into the code, then I found that the true flag (value of `ETHEREUM_NODE_ADD_TRANSCATION_REVERT_REASON`) was not even getting propagated from the environment variable. 

After debugging it thoroughly, and spending ~6 hours I found the fix. 
internally `ethereum.nodes[0].addTransactionRevertReason` is being searched in the environment. So, Ideally, the flag should be `ETHEREUM_NODES_0_ADD_TRANSACTION_REVERT_REASON `(and not `ETHEREUM_NODE_ADD_TRANSCATION_REVERT_REASON` as mentioned in the official documentation). 
Still, it didn't work by just changing the environment variable name, Finally, I had to refactor addTransactionRevertReason to `add.transaction.revert.reason` for it to work.

I have tested it on my local Ganache network and on the Quorum node. It was working like a charm.

**Note**: You have to make sure that you add this line of code.
[`web3.eth.handleRevert = true;`](https://web3js.readthedocs.io/en/v1.3.4/web3-eth.html#handlerevert) before submitting any transaction to the ledger, for this feature to work.
